### PR TITLE
Add dotnet 6.0 support.

### DIFF
--- a/ImageListView/ImageListView.csproj
+++ b/ImageListView/ImageListView.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net35</TargetFramework>
+	<TargetFrameworks>net35;net6.0-windows</TargetFrameworks>
 	<OutputType>Library</OutputType>
 	<RootNamespace>Manina.Windows.Forms</RootNamespace>
   </PropertyGroup>
@@ -39,7 +39,7 @@
 	<WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
 	<Reference Include="System.Design" />
   </ItemGroup>
 

--- a/ImageListView/ImageListView.csproj
+++ b/ImageListView/ImageListView.csproj
@@ -1,220 +1,96 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{0C295FB8-C6C6-4A40-9F19-05A43F353A04}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Manina.Windows.Forms</RootNamespace>
-    <AssemblyName>ImageListView</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
+	<TargetFramework>net35</TargetFramework>
+	<OutputType>Library</OutputType>
+	<RootNamespace>Manina.Windows.Forms</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+	<UseWindowsForms>true</UseWindowsForms>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;BONUSPACK;USEWIC;BENCHMARK</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
+	<DefineConstants>TRACE;DEBUG;BONUSPACK;USEWIC;BENCHMARK</DefineConstants>
+	<DocumentationFile></DocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;USEWIC</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
+	<DefineConstants>TRACE;USEWIC</DefineConstants>
+	<UseVSHostingProcess>false</UseVSHostingProcess>
+	<DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug without WPF|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug without WPF\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;BONUSPACK;BENCHMARK</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	<DebugSymbols>true</DebugSymbols>
+	<OutputPath>bin\Debug without WPF\</OutputPath>
+	<DefineConstants>TRACE;DEBUG;BONUSPACK;BENCHMARK</DefineConstants>
+	<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release without WPF|AnyCPU'">
-    <OutputPath>bin\Release without WPF\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <WarningLevel>0</WarningLevel>
+	<OutputPath>bin\Release without WPF\</OutputPath>
+	<DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
+	<Optimize>true</Optimize>
+	<UseVSHostingProcess>false</UseVSHostingProcess>
+	<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	<WarningLevel>0</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
+	<Reference Include="System.Design" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="GDIMetadataExtractor.cs" />
-    <Compile Include="GDIShellInfoExtractor.cs" />
-    <Compile Include="GDIThumbnailExtractor.cs" />
-    <Compile Include="IExtractor.cs" />
-    <Compile Include="IGrouper.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewSubItem.cs" />
-    <Compile Include="ImageListViewSubItemCollection.cs" />
-    <Compile Include="Metadata.cs" />
-    <Compile Include="PersistentCache.cs" />
-    <Compile Include="ImageListViewGroupCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewGroup.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewItemAdaptors.cs">
-    </Compile>
-    <Compile Include="ImageListViewCacheMetadata.cs" />
-    <Compile Include="ImageListViewCacheShellInfo.cs" />
-    <Compile Include="ImageListViewCacheThumbnail.cs" />
-    <Compile Include="ImageListViewItemAdaptor.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="QueuedBackgroundWorkerEvents.cs">
-    </Compile>
-    <Compile Include="ImageListViewItemTypeConverter.cs" />
-    <Compile Include="OpenFileDialogEditor.cs" />
-    <Compile Include="ImageListViewColumnHeaderTypeConverter.cs" />
-    <Compile Include="QueuedBackgroundWorker.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewColorTypeConverter.cs" />
-    <Compile Include="ImageListViewCheckedItemCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewColor.cs" />
-    <Compile Include="ImageListViewResources.de.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>ImageListViewResources.de.resx</DependentUpon>
-    </Compile>
-    <Compile Include="ImageListViewResources.tr.Designer.cs">
-      <DependentUpon>ImageListViewResources.tr.resx</DependentUpon>
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-    </Compile>
-    <Compile Include="ImageListViewRenderers.cs" />
-    <Compile Include="Enums.cs" />
-    <Compile Include="Events.cs" />
-    <Compile Include="HitInfo.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListView.cs" />
-    <Compile Include="ImageListViewColumnHeader.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewColumnHeaderCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewDesigner.cs">
-    </Compile>
-    <Compile Include="ImageListViewItem.cs" />
-    <Compile Include="ImageListViewItemCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewLayoutManager.cs">
-    </Compile>
-    <Compile Include="ImageListViewRenderer.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewSelectedItemCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ImageListViewNavigationManager.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ImageListViewResources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>ImageListViewResources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Extractor.cs" />
-    <Compile Include="ShellInfo.cs" />
-    <Compile Include="Utility.cs" />
-    <Service Include="{94E38DFF-614B-4cbd-B67C-F211BB35CE8B}" />
+	<Compile Update="IGrouper.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewGroupCollection.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewGroup.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewItemAdaptor.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="QueuedBackgroundWorker.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewCheckedItemCollection.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="HitInfo.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewColumnHeader.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewColumnHeaderCollection.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewItemCollection.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewRenderer.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewSelectedItemCollection.cs">
+	  <SubType>Component</SubType>
+	</Compile>
+	<Compile Update="ImageListViewNavigationManager.cs">
+	  <SubType>Component</SubType>
+	</Compile>
   </ItemGroup>
+
   <ItemGroup>
-    <EmbeddedResource Include="ImageListViewResources.de.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ImageListViewResources.de.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="ImageListViewResources.tr.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ImageListViewResources.tr.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="ImageListView.bmp" />
-    <EmbeddedResource Include="ImageListViewResources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ImageListViewResources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
+	<EmbeddedResource Include="ImageListView.bmp" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="app.config" />
+	<EmbeddedResource Include="QueuedBackgroundWorker.bmp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\DefaultImage.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ErrorImage.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\SortAscending.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\SortDescending.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\RatingImage.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\EmptyRatingImage.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="QueuedBackgroundWorker.bmp" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\DragDropCursor_Copy.cur" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\DragDropCursor_Move.cur" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\DragDropCursor_No.cur" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/ImageListView/ImageListView.csproj
+++ b/ImageListView/ImageListView.csproj
@@ -12,7 +12,16 @@
 	<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup>
+	<AnalysisLevel>latest</AnalysisLevel>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+	<NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -29,14 +38,12 @@
 	<DebugSymbols>true</DebugSymbols>
 	<OutputPath>bin\Debug without WPF\</OutputPath>
 	<DefineConstants>TRACE;DEBUG;BONUSPACK;BENCHMARK</DefineConstants>
-	<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release without WPF|AnyCPU'">
 	<OutputPath>bin\Release without WPF\</OutputPath>
 	<Optimize>true</Optimize>
 	<UseVSHostingProcess>false</UseVSHostingProcess>
-	<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
 	<WarningLevel>0</WarningLevel>
   </PropertyGroup>
 

--- a/ImageListView/ImageListView.csproj
+++ b/ImageListView/ImageListView.csproj
@@ -12,15 +12,17 @@
 	<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 	<DefineConstants>TRACE;DEBUG;BONUSPACK;USEWIC;BENCHMARK</DefineConstants>
-	<DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
 	<DefineConstants>TRACE;USEWIC</DefineConstants>
 	<UseVSHostingProcess>false</UseVSHostingProcess>
-	<DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug without WPF|AnyCPU'">
@@ -32,7 +34,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release without WPF|AnyCPU'">
 	<OutputPath>bin\Release without WPF\</OutputPath>
-	<DocumentationFile>bin\Release\ImageListView.xml</DocumentationFile>
 	<Optimize>true</Optimize>
 	<UseVSHostingProcess>false</UseVSHostingProcess>
 	<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>

--- a/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
+++ b/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
@@ -1,52 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{819A4362-3A60-4FEA-B193-5BAA2FAFFC3F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Manina.Windows.Forms</RootNamespace>
-    <AssemblyName>WPFThumbnailExtractor</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+	<TargetFramework>net35</TargetFramework>
+	<OutputType>Library</OutputType>
+	<RootNamespace>Manina.Windows.Forms</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup>
+	<UseWPF>true</UseWPF>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="WindowsBase" />
+	<ProjectReference Include="..\ImageListView\ImageListView.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="WPFMetadataExtractor.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="WPFThumbnailExtractor.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ImageListView\ImageListView.csproj">
-      <Project>{0c295fb8-c6c6-4a40-9f19-05a43f353a04}</Project>
-      <Name>ImageListView</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
+++ b/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
@@ -12,6 +12,15 @@
 	<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
 
+  <PropertyGroup>
+	<AnalysisLevel>latest</AnalysisLevel>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+	<NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
 	<ProjectReference Include="..\ImageListView\ImageListView.csproj" />
   </ItemGroup>

--- a/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
+++ b/WPFThumbnailExtractor/WPFThumbnailExtractor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net35</TargetFramework>
+	<TargetFrameworks>net35;net6.0-windows</TargetFrameworks>
 	<OutputType>Library</OutputType>
 	<RootNamespace>Manina.Windows.Forms</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Closes: #222, Closes: #226, Closes: #229

## Summary:
- **ImageListView** and **WPFThumbnailExtractor** projects has been migrated to the sdk-style project format.
- Target frameworks has been set to `net35` and `net6.0` to stay compatible with older versions  of dotnet.
- The `DocumentationFile` properties has been replaced with `GenerateDocumentationFile` property.
- The `CodeAnalysisRuleSet` properties has been replaced with [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview).

## Current issues
- Packing the library using `dotnet pack` command fails.
```
dotnet pack .\ImageListView\ImageListView.csproj -c Release
```
```
error : ResGen.exe not supported on .NET Core MSBuild
```

- Packing the sdk-style projects using `nuget pack` command [is not supported](https://github.com/NuGet/Home/issues/4491#issuecomment-586031570).

I think package properties should be moved from **ImageListView.nuspec** to **ImageListView.csproj** (or alternatively **Directory.Build.props**) then pack it via `dotnet pack` or `msbuild -t:pack`.

That being said, I'm not exactly sure how to include `WPFThumbnailExtractor.dll` into the package.

## Out of scope
Serving the documentations fails with the following error which can be solved by updating the `docfx.console` nuget package.
```
The SDK 'Microsoft.NET.Sdk' specified could not be found.
```