### PR TITLE
When ImageListView lost focus,the value of ShiftKey and ControlKey sh…

### DIFF
--- a/ImageListView/ImageListView.cs
+++ b/ImageListView/ImageListView.cs
@@ -2000,6 +2000,7 @@ namespace Manina.Windows.Forms
         /// <param name="e">An <see cref="T:System.EventArgs"/> that contains the event data.</param>
         protected override void OnLostFocus(EventArgs e)
         {
+            navigationManager.LostFocus(e);
             base.OnLostFocus(e);
             Refresh();
         }

--- a/ImageListView/ImageListViewNavigationManager.cs
+++ b/ImageListView/ImageListViewNavigationManager.cs
@@ -818,6 +818,15 @@ namespace Manina.Windows.Forms
                 ShiftKey = (e.Modifiers & Keys.Shift) == Keys.Shift;
                 ControlKey = (e.Modifiers & Keys.Control) == Keys.Control;
             }
+
+            /// <summary>
+            /// Handles the LostFocus event.
+            /// </summary>
+            public void LostFocus(EventArgs e)
+            {
+                ShiftKey = false;
+                ControlKey = false;
+            }
             #endregion
 
             #region Drag and Drop Event Handlers


### PR DESCRIPTION
When lmagelistView lost focus the value of "Shifkey" and "Controkey" should be set to "false".
Because in this scenario keyup event will not fire.