### PR TITLE
Add missing SuspendPaint in SelectWhere, UnselectWhere

### DIFF
--- a/ImageListView/ImageListView.cs
+++ b/ImageListView/ImageListView.cs
@@ -1107,6 +1107,8 @@ namespace Manina.Windows.Forms
         /// </summary>
         public void SelectWhere(Func<ImageListViewItem, bool> predicate)
         {
+            SuspendPaint();
+
             foreach (ImageListViewItem item in Items.Where(predicate))
                 item.mSelected = true;
 
@@ -1120,6 +1122,8 @@ namespace Manina.Windows.Forms
         /// </summary>
         public void UnselectWhere(Func<ImageListViewItem, bool> predicate)
         {
+            SuspendPaint();
+
             foreach (ImageListViewItem item in Items.Where(predicate))
                 item.mSelected = false;
 


### PR DESCRIPTION
`SuspendPaint` was missing to match the `ResumePaint` call in these two functions, thus throwing off the counter, and causing all kinds of visual issues when attempting to use these functions.